### PR TITLE
set uios element to NULL in UIO_UNMAP

### DIFF
--- a/libuio.c
+++ b/libuio.c
@@ -112,6 +112,7 @@ uint8_t UIO_UNMAP(void * blockToFree) {
 			munmap(arrayItem->mapPtr, arrayItem->map_size);
 			close(arrayItem->uio_fd);
 			free(arrayItem);
+			uios[i] = NULL;
 			//fprintf(stderr, "UIO device unmapped successfully\n");
 			return 0;
 		}


### PR DESCRIPTION
Currently uios elements are not cleared during the call to UIO_UNMAP causing issues. This is fixes that problem.